### PR TITLE
OAS Required Type Change

### DIFF
--- a/src/main/java/com/apigee/oas/OASUtils.java
+++ b/src/main/java/com/apigee/oas/OASUtils.java
@@ -90,7 +90,7 @@ public class OASUtils {
     	
     	parameter.addProperty("name", name);
     	parameter.addProperty("in", "body");
-    	parameter.addProperty("required", "true");
+    	parameter.addProperty("required", true);
     	parameter.add("schema", schemaReference);
     	parameters.add(parameter);
     	


### PR DESCRIPTION
https://github.com/apigee/wsdl2apigee/issues/13

Changed the required field generation in getBodyParameter() from quoted string to boolean value representation to be in line with Swagger required type for this field.