### PR TITLE
Adding a set of test wsdls and corresponding golden output OAS files.

### DIFF
--- a/src/test/java/com/apigee/proxywriter/GenerateProxyTest.java
+++ b/src/test/java/com/apigee/proxywriter/GenerateProxyTest.java
@@ -67,7 +67,7 @@ public class GenerateProxyTest {
     private void assertSpecConversion(String wsdlPath, String portName, String goldenOasPath) throws Exception {
         final String convertedOasContent = getOasConversionFromWsdl(wsdlPath, portName);
         final String goldenOasContent = readResourceContent(goldenOasPath);
-        JSONAssert.assertEquals(convertedOasContent, goldenOasContent, JSONCompareMode.STRICT);
+        JSONAssert.assertEquals(goldenOasContent, convertedOasContent, JSONCompareMode.STRICT);
     }
 
     private void checkForFilesInBundle(List<String> filenames, InputStream inputStream) throws IOException {
@@ -520,4 +520,41 @@ public class GenerateProxyTest {
         final String portName = "sanityPort";
         assertSpecConversion(wsdlPath, portName, oasPath);
     }
+
+    // TODO(b/112275181): re-enable once corresponding bug is fixed
+    //@Test
+    public void testSpecConversion_b_112275181() throws Exception {
+        final String wsdlPath = "/spec-conversion/b-112275181_wsdl.xml";
+        final String oasPath = "/spec-conversion/b-112275181_oas.json";
+        final String portName = "testPort";
+        assertSpecConversion(wsdlPath, portName, oasPath);
+    }
+
+    // TODO(b/112274526): re-enable once corresponding bug is fixed
+    //@Test
+    public void testSpecConversion_b_112274526() throws Exception {
+        final String wsdlPath = "/spec-conversion/b-112274526_wsdl.xml";
+        final String oasPath = "/spec-conversion/b-112274526_oas.json";
+        final String portName = "testPort";
+        assertSpecConversion(wsdlPath, portName, oasPath);
+    }
+
+    // TODO(b/112274566): re-enable once corresponding bug is fixed
+    //@Test
+    public void testSpecConversion_b_112274566() throws Exception {
+        final String wsdlPath = "/spec-conversion/b-112274566_wsdl.xml";
+        final String oasPath = "/spec-conversion/b-112274566_oas.json";
+        final String portName = "testPort";
+        assertSpecConversion(wsdlPath, portName, oasPath);
+    }
+
+    // TODO(b/112274847): re-enable once corresponding bug is fixed
+    //@Test
+    public void testSpecConversion_b_112274847() throws Exception {
+        final String wsdlPath = "/spec-conversion/b-112274847_wsdl.xml";
+        final String oasPath = "/spec-conversion/b-112274847_oas.json";
+        final String portName = "testPort";
+        assertSpecConversion(wsdlPath, portName, oasPath);
+    }
+
 }

--- a/src/test/resources/spec-conversion/b-112274526_oas.json
+++ b/src/test/resources/spec-conversion/b-112274526_oas.json
@@ -1,0 +1,67 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "testService",
+    "description": "A OAS document generated from WSDL",
+    "termsOfService": "",
+    "contact": {
+      "name": "API Team"
+    },
+    "license": {
+      "name": "Apache 2.0"
+    }
+  },
+  "host": "@request.header.host#",
+  "basePath": "/basepath",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/testoperation": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "schema": {
+              "$ref": "#/definitions/testResponse"
+            }
+          }
+        },
+        "description": "Implements WSDL operation testOperation",
+        "parameters": []
+      }
+    }
+  },
+  "definitions": {
+    "testResponse": {
+      "properties": {
+          "testList": {
+              "type": "array",
+              "minItems": 0,
+              "items": {
+                  "$ref": "#/definitions/testType"
+              }
+        }
+      },
+      "type": "object"
+    },
+    "testType": {
+        "properties": {
+            "field1": {
+                "type": "int"
+            },
+            "field2": {
+                "type": "string"
+            }
+        },
+      "type": "object"
+    }
+  }
+}

--- a/src/test/resources/spec-conversion/b-112274526_oas.json
+++ b/src/test/resources/spec-conversion/b-112274526_oas.json
@@ -3,7 +3,7 @@
   "info": {
     "version": "1.0.0",
     "title": "testService",
-    "description": "A OAS document generated from WSDL",
+    "description": "An OAS document generated from WSDL",
     "termsOfService": "",
     "contact": {
       "name": "API Team"

--- a/src/test/resources/spec-conversion/b-112274526_wsdl.xml
+++ b/src/test/resources/spec-conversion/b-112274526_wsdl.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="ConversionTest" targetNamespace="http://apigee.com/conversion-test"
+                  xmlns:this="http://apigee.com/conversion-test"
+                  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+  <wsdl:types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://apigee.com/conversion-test">
+
+      <xs:element name="testRequest" type="xs:string" />
+
+      <xs:complexType name="testType">
+        <xs:element name="field1" type="xs:int" />
+        <xs:element name="field2" type="xs:string" />
+      </xs:complexType>
+      <xs:element name="testResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" name="testList" type="this:testType"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+
+    </xs:schema>
+  </wsdl:types>
+
+  <wsdl:message name="testOperationRequest">
+    <wsdl:part name="testValue" element="this:testRequest" />
+  </wsdl:message>
+  <wsdl:message name="testOperationResponse">
+    <wsdl:part name="testValue" element="this:testResponse" />
+  </wsdl:message>
+
+  <wsdl:portType name="testPortType">
+    <wsdl:operation name="testOperation">
+      <wsdl:input message="this:testOperationRequest" />
+      <wsdl:output message="this:testOperationResponse" />
+    </wsdl:operation>
+  </wsdl:portType>
+
+  <wsdl:binding name="testBinding" type="this:testPortType">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http" />
+    <wsdl:operation name="testOperation">
+      <soap:operation soapAction="http://apigee.com/conversion-test" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+
+  <wsdl:service name="testService">
+    <wsdl:port name="testPort" binding="this:testBinding">
+      <soap:address location="http://apigee.com/conversion-test"/>
+    </wsdl:port>
+  </wsdl:service>
+
+</wsdl:definitions>

--- a/src/test/resources/spec-conversion/b-112274566_oas.json
+++ b/src/test/resources/spec-conversion/b-112274566_oas.json
@@ -3,7 +3,7 @@
   "info": {
     "version": "1.0.0",
     "title": "testService",
-    "description": "A OAS document generated from WSDL",
+    "description": "An OAS document generated from WSDL",
     "termsOfService": "",
     "contact": {
       "name": "API Team"

--- a/src/test/resources/spec-conversion/b-112274566_oas.json
+++ b/src/test/resources/spec-conversion/b-112274566_oas.json
@@ -1,0 +1,66 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "testService",
+    "description": "A OAS document generated from WSDL",
+    "termsOfService": "",
+    "contact": {
+      "name": "API Team"
+    },
+    "license": {
+      "name": "Apache 2.0"
+    }
+  },
+  "host": "@request.header.host#",
+  "basePath": "/basepath",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/testoperation": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "schema": {
+              "$ref": "#/definitions/testResponse"
+            }
+          }
+        },
+        "description": "Implements WSDL operation testOperation",
+        "parameters": []
+      }
+    }
+  },
+  "definitions": {
+    "testResponse": {
+        "properties": {
+            "field3": {
+                "type": "int"
+            },
+            "field4": {
+                "type": "string"
+            },
+            "nestedField": {
+                "type": "object",
+                "properties": {
+                    "field1": {
+                        "type": "int"
+                    },
+                    "field2": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+      "type": "object"
+    }
+  }
+}

--- a/src/test/resources/spec-conversion/b-112274566_wsdl.xml
+++ b/src/test/resources/spec-conversion/b-112274566_wsdl.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="ConversionTest" targetNamespace="http://apigee.com/conversion-test"
+                  xmlns:this="http://apigee.com/conversion-test"
+                  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+  <wsdl:types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://apigee.com/conversion-test">
+
+      <xs:element name="testRequest" type="xs:string" />
+
+      <xs:complexType name="testType1">
+        <xs:element name="field1" type="xs:int" />
+        <xs:element name="field2" type="xs:string" />
+      </xs:complexType>
+      <xs:complexType name="testType2">
+        <xs:element name="field3" type="xs:int" />
+        <xs:element name="field4" type="xs:string" />
+        <xs:element name="nestedField" type="this:testType1" />
+      </xs:complexType>
+      <xs:element name="testResponse" type="this:testType2" />
+
+    </xs:schema>
+  </wsdl:types>
+
+  <wsdl:message name="testOperationRequest">
+    <wsdl:part name="testValue" element="this:testRequest" />
+  </wsdl:message>
+  <wsdl:message name="testOperationResponse">
+    <wsdl:part name="testValue" element="this:testResponse" />
+  </wsdl:message>
+
+  <wsdl:portType name="testPortType">
+    <wsdl:operation name="testOperation">
+      <wsdl:input message="this:testOperationRequest" />
+      <wsdl:output message="this:testOperationResponse" />
+    </wsdl:operation>
+  </wsdl:portType>
+
+  <wsdl:binding name="testBinding" type="this:testPortType">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http" />
+    <wsdl:operation name="testOperation">
+      <soap:operation soapAction="http://apigee.com/conversion-test" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+
+  <wsdl:service name="testService">
+    <wsdl:port name="testPort" binding="this:testBinding">
+      <soap:address location="http://apigee.com/conversion-test"/>
+    </wsdl:port>
+  </wsdl:service>
+
+</wsdl:definitions>

--- a/src/test/resources/spec-conversion/b-112274847_oas.json
+++ b/src/test/resources/spec-conversion/b-112274847_oas.json
@@ -1,0 +1,66 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "testService",
+    "description": "A OAS document generated from WSDL",
+    "termsOfService": "",
+    "contact": {
+      "name": "API Team"
+    },
+    "license": {
+      "name": "Apache 2.0"
+    }
+  },
+  "host": "@request.header.host#",
+  "basePath": "/basepath",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/testoperation2": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "schema": {
+              "$ref": "#/definitions/leakyItem"
+            }
+          }
+        },
+        "description": "Implements WSDL operation testOperation2",
+        "parameters": []
+      }
+    },
+    "/testoperation1": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "schema": {
+              "$ref": "#/definitions/genericItem"
+            }
+          }
+        },
+        "description": "Implements WSDL operation testOperation1",
+        "parameters": []
+      }
+    }
+  },
+  "definitions": {
+    "leakyItem": {
+      "properties": {
+        "leakyField": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  }
+}

--- a/src/test/resources/spec-conversion/b-112274847_oas.json
+++ b/src/test/resources/spec-conversion/b-112274847_oas.json
@@ -3,7 +3,7 @@
   "info": {
     "version": "1.0.0",
     "title": "testService",
-    "description": "A OAS document generated from WSDL",
+    "description": "An OAS document generated from WSDL",
     "termsOfService": "",
     "contact": {
       "name": "API Team"

--- a/src/test/resources/spec-conversion/b-112274847_wsdl.xml
+++ b/src/test/resources/spec-conversion/b-112274847_wsdl.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="ConversionTest" targetNamespace="http://apigee.com/conversion-test"
+                  xmlns:this="http://apigee.com/conversion-test"
+                  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+  <wsdl:types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://apigee.com/conversion-test">
+
+	  <xs:element name="genericItem" type="xs:string" />
+
+	  <xs:element name="leakyItem">
+		<xs:complexType>
+		  <xs:sequence>
+			<xs:element minOccurs="0" maxOccurs="1" name="leakyField" type="xs:string"/>
+		  </xs:sequence>
+		</xs:complexType>
+	  </xs:element>
+
+    </xs:schema>
+  </wsdl:types>
+
+  <wsdl:message name="genericMessage">
+    <wsdl:part name="testValue" element="this:genericItem" />
+  </wsdl:message>
+  <wsdl:message name="leakyMessage">
+    <wsdl:part name="testValue" element="this:leakyItem" />
+  </wsdl:message>
+
+  <wsdl:portType name="testPortType">
+    <!-- order of these operations matters, if these are switched the bug won't repro -->
+    <wsdl:operation name="testOperation2">
+      <wsdl:input message="this:genericMessage" />
+      <wsdl:output message="this:leakyMessage" />
+    </wsdl:operation>
+    <wsdl:operation name="testOperation1">
+      <wsdl:input message="this:genericMessage" />
+      <wsdl:output message="this:genericMessage" />
+    </wsdl:operation>
+  </wsdl:portType>
+
+  <wsdl:binding name="testBinding" type="this:testPortType">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http" />
+    <wsdl:operation name="testOperation1">
+      <soap:operation soapAction="http://apigee.com/conversion-test" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+
+  <wsdl:service name="testService">
+    <wsdl:port name="testPort" binding="this:testBinding">
+      <soap:address location="http://apigee.com/conversion-test"/>
+    </wsdl:port>
+  </wsdl:service>
+
+</wsdl:definitions>

--- a/src/test/resources/spec-conversion/b-112275181_oas.json
+++ b/src/test/resources/spec-conversion/b-112275181_oas.json
@@ -1,0 +1,69 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "testService",
+    "description": "A OAS document generated from WSDL",
+    "termsOfService": "",
+    "contact": {
+      "name": "API Team"
+    },
+    "license": {
+      "name": "Apache 2.0"
+    }
+  },
+  "host": "@request.header.host#",
+  "basePath": "/basepath",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/testoperation": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "schema": {
+              "$ref": "#/definitions/testExtension"
+            }
+          }
+        },
+        "description": "Implements WSDL operation testOperation",
+          "parameters": [
+              {
+                  "enum": [
+                      "valueOne",
+                      "valueTwo"
+                  ],
+                  "in": "query",
+                  "name": "testValue",
+                  "required": true,
+                  "type": "string"
+              }
+          ]
+      }
+    }
+  },
+  "definitions": {
+    "testExtension": {
+        "properties": {
+            "baseElement1": {
+                "type": "string"
+            },
+            "baseElement2": {
+                "type": "string"
+            },
+            "extendedAttribute": {
+                "type": "string"
+            }
+      },
+      "type": "object"
+    }
+  }
+}

--- a/src/test/resources/spec-conversion/b-112275181_oas.json
+++ b/src/test/resources/spec-conversion/b-112275181_oas.json
@@ -3,7 +3,7 @@
   "info": {
     "version": "1.0.0",
     "title": "testService",
-    "description": "A OAS document generated from WSDL",
+    "description": "An OAS document generated from WSDL",
     "termsOfService": "",
     "contact": {
       "name": "API Team"

--- a/src/test/resources/spec-conversion/b-112275181_wsdl.xml
+++ b/src/test/resources/spec-conversion/b-112275181_wsdl.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="ConversionTest" targetNamespace="http://apigee.com/conversion-test"
+                  xmlns:this="http://apigee.com/conversion-test"
+                  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+  <wsdl:types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://apigee.com/conversion-test">
+
+      <xs:element name="testEnum">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="valueOne" />
+            <xs:enumeration value="valueTwo" />
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+
+      <xs:complexType name="baseType">
+        <xs:sequence>
+          <xs:element name="baseElement1" type="xs:string" />
+          <xs:element name="baseElement2" type="xs:string" />
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="testExtension">
+        <xs:complexType>
+          <xs:simpleContent>
+            <xs:extension base="this:baseType">
+              <xs:attribute name="extendedAttribute">
+                <xs:element type="xs:string" />
+              </xs:attribute>
+            </xs:extension>
+          </xs:simpleContent>
+        </xs:complexType>
+      </xs:element>
+
+    </xs:schema>
+  </wsdl:types>
+
+  <wsdl:message name="testOperationRequest">
+    <wsdl:part name="testValue" element="this:testEnum" />
+  </wsdl:message>
+  <wsdl:message name="testOperationResponse">
+    <wsdl:part name="testValue" element="this:testExtension" />
+  </wsdl:message>
+
+  <wsdl:portType name="testPortType">
+    <wsdl:operation name="testOperation">
+      <wsdl:input message="this:testOperationRequest" />
+      <wsdl:output message="this:testOperationResponse" />
+    </wsdl:operation>
+  </wsdl:portType>
+
+  <wsdl:binding name="testBinding" type="this:testPortType">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http" />
+    <wsdl:operation name="testOperation">
+      <soap:operation soapAction="http://apigee.com/conversion-test" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+
+  <wsdl:service name="testService">
+    <wsdl:port name="testPort" binding="this:testBinding">
+      <soap:address location="http://apigee.com/conversion-test"/>
+    </wsdl:port>
+  </wsdl:service>
+
+</wsdl:definitions>

--- a/src/test/resources/spec-conversion/sanity_oas.json
+++ b/src/test/resources/spec-conversion/sanity_oas.json
@@ -3,7 +3,7 @@
   "info": {
     "version": "1.0.0",
     "title": "sanityService",
-    "description": "A OAS document generated from WSDL",
+    "description": "An OAS document generated from WSDL",
     "termsOfService": "",
     "contact": {
       "name": "API Team"


### PR DESCRIPTION
These test cases represent some bugs found in customer docs. The corresponding unit tests are all failing (disabled). Next step is to fix the conversion logic being exercised here.