### PR TITLE
Added a boundary check for the parts in the message when creating a passthrough proxy from a WSDL file

### DIFF
--- a/src/main/java/com/apigee/proxywriter/GenerateProxy.java
+++ b/src/main/java/com/apigee/proxywriter/GenerateProxy.java
@@ -2442,9 +2442,11 @@ public class GenerateProxy {
 					if (RPCSTYLE) {
 						apiMap = new APIMap(null, null, null, "POST", op.getName(), false);
 					} else {
-						// get root element
-						com.predic8.schema.Element requestElement = op.getInput().getMessage().getParts().get(0)
-								.getElement();
+						com.predic8.schema.Element requestElement = null;
+						if (op.getInput().getMessage().getParts().size() > 0) {
+							// get root element
+							requestElement = op.getInput().getMessage().getParts().get(0).getElement();
+						}
 						if (requestElement != null) {
 							apiMap = new APIMap(null, null, null, "POST", requestElement.getName(), false);
 						} else {


### PR DESCRIPTION
There was no check whether parts are in the message when creating a SOAP passthrough proxy from a WSDL file. I added a check on the size of the parts.