### PR TITLE
Avoid NPE when WSDL does not contain SOAPAction

### DIFF
--- a/src/main/java/com/apigee/proxywriter/GenerateProxy.java
+++ b/src/main/java/com/apigee/proxywriter/GenerateProxy.java
@@ -2594,10 +2594,11 @@ public class GenerateProxy {
 							continue;
 						}
 						if (bnd.getBinding() instanceof AbstractSOAPBinding) {
+							String soapAction = getOperationSOAPAction(bop);
 							LOGGER.fine("Found Operation Name: " + bop.getName() + " SOAPAction: "
-									+ bop.getOperation().getSoapAction());
+									+ soapAction);
 							APIMap apiM = messageTemplates.get(bop.getName());
-							apiM.setSoapAction(bop.getOperation().getSoapAction());
+							apiM.setSoapAction(soapAction);
 							messageTemplates.put(bop.getName(), apiM);
 						}
 					}
@@ -2606,6 +2607,15 @@ public class GenerateProxy {
 		}
 		LOGGER.exiting(GenerateProxy.class.getName(), new Object() {
 		}.getClass().getEnclosingMethod().getName());
+	}
+
+	private String getOperationSOAPAction(BindingOperation bop) {
+		ExtensibilityOperation op = bop.getOperation();
+		if (op == null) {
+			return null;
+		}
+
+		return op.getSoapAction();
 	}
 
 	private String generateOAS() throws Exception {


### PR DESCRIPTION
In some scenarios, when using a SOAP 1.2 WSDL,
there will be no SOAPAction specified.

When this happens, the tool errors out with an NPE.